### PR TITLE
Fix the conversion error from YUV to RGB

### DIFF
--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -97,8 +97,8 @@ Java_facebook_f8demo_ClassifyCamera_classificationFromCaffe2(
 
     for (auto i = 0; i < iter_h; ++i) {
         jbyte* Y_row = &Y_data[(h_offset + i) * w];
-        jbyte* U_row = &U_data[(h_offset + i) / 4 * rowStride];
-        jbyte* V_row = &V_data[(h_offset + i) / 4 * rowStride];
+        jbyte* U_row = &U_data[(h_offset + i) / 2 * rowStride];
+        jbyte* V_row = &V_data[(h_offset + i) / 2 * rowStride];
         for (auto j = 0; j < iter_w; ++j) {
             // Tested on Pixel and S7.
             char y = Y_row[w_offset + j];


### PR DESCRIPTION
The structure for YUV420 in Android is not the same as the one in [this](https://en.wikipedia.org/wiki/YUV#Y.E2.80.B2UV420p_.28and_Y.E2.80.B2V12_or_YV12.29_to_RGB888_conversion).There are several formats for YUV420. And when I print the length for Y U V channel, I got 'Y_len:76800 U_len:38399 V_len:38399'. And I think the reason for this result is that the YUV420 [format](https://msdn.microsoft.com/en-us/library/windows/desktop/dd206750(v=vs.85).aspx) in Android is NV12 rather than YV12.  The U and V channels share the same plane, so the memory location for U and V channels should be divided by 2 rather than 4. 

I have also done some experiments: print the input_data in JNI to a file
```
if(writingdata){
        alog("Writing input data\n");
        std::ofstream ofs("/sdcard/test.txt",std::ios::out|std::ios::trunc);
        for (int i=0;i<MAX_DATA_SIZE;i++){
            ofs<<input_data[i]<<std::endl;
        }
        ofs.close();
    }
```
pull the file with ADB and restore the picture with [this](https://gist.github.com/spencial/528a1531436613d4230bb8d9f89fff9e) on PC. If dividing the memory location for U and V by 4, the location of color in restored pictures will shift greatly. However, if the location is divided by 2, the restored picture is correct. I have tested on OnePlus 5 and Pixel. And after this revision, the accuracy of the output became better and can compete with the results on PC.